### PR TITLE
Pass allIssues into generateId to fix id bug

### DIFF
--- a/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
@@ -98,7 +98,7 @@ function App() {
       } else {
         // Add a new issue at the end of the list
         newIssues.push({
-          id: generateId(),
+          id: generateId(allIssues),
           title,
           description,
           completed: false,

--- a/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
@@ -72,7 +72,7 @@ function App() {
       } else {
         // Add a new issue at the end of the list
         newIssues.push({
-          id: generateId(),
+          id: generateId(allIssues),
           title,
           description,
           completed: false,

--- a/extensions/issue-tracker-action/src/ActionExtension.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension.jsx
@@ -58,7 +58,7 @@ function App() {
       await updateIssues(data.selected[0].id, [
         ...allIssues,
         {
-          id: generateId(),
+          id: generateId(allIssues),
           completed: false,
           ...issue,
         }


### PR DESCRIPTION
### Issue

All issues were being deleted when clicking the icon to delete a single issue. This was because the issues were being created with the same ID. 

### Solution

Pass `allIssues` into the `generateId` function when an issue is created so the ID can be generated based on the length of the issue list.

https://github.com/Shopify/example-admin--action-and-block--react/assets/7654369/3aeadc1d-4a0d-4393-9f41-c2a5cb05f041

