### PR TITLE
Remove TS directive and fix variants util

### DIFF
--- a/extensions/issue-tracker-conditional-action/src/condition/shouldRender.js
+++ b/extensions/issue-tracker-conditional-action/src/condition/shouldRender.js
@@ -1,7 +1,3 @@
-// [START conditional-action-extension.directive]
-/// <reference types="@shopify/ui-extensions/admin" />
-// [END conditional-action-extension.directive]
-
 // [START conditional-action-extension.module]
 import { getProductVariants } from "../utils";
 

--- a/extensions/issue-tracker-conditional-action/src/utils.js
+++ b/extensions/issue-tracker-conditional-action/src/utils.js
@@ -92,6 +92,6 @@ export async function getProductVariants(data) {
   }
 
   const productData = await res.json();
-  return productData.data.product.variants;
+  return productData.data.product.variants.edges;
 };
 // [END conditional-action-extension.utils]


### PR DESCRIPTION
This PR: 

- Removes the`ts` comment directive in the `js` code example
- Fixes the return value on the variants utility function